### PR TITLE
Fix function pointer fields share parameters

### DIFF
--- a/src/CppAst.Tests/TestFunctions.cs
+++ b/src/CppAst.Tests/TestFunctions.cs
@@ -109,6 +109,56 @@ typedef void (*function1)(int, float);
             );
         }
 
+        [Test]
+        public void TestFunctionFields()
+        {
+            ParseAssert(@"
+typedef struct struct0 {
+    void (*function0)(int a, float b);
+    void (*function1)(char, int);
+} struct0;
+",
+                compilation =>
+                {
+                    Assert.False(compilation.HasErrors);
+
+                    var cls = compilation.Classes[0];
+                    Assert.AreEqual(2, cls.Fields.Count);
+
+                    {
+                        var cppType = cls.Fields[0].Type;
+                        Assert.AreEqual(CppTypeKind.Pointer, cppType.TypeKind);
+                        var cppPointerType = (CppPointerType) cppType;
+                        Assert.AreEqual(CppTypeKind.Function, cppPointerType.ElementType.TypeKind);
+                        var cppFunctionType = (CppFunctionType) cppPointerType.ElementType;
+                        Assert.AreEqual(2, cppFunctionType.Parameters.Count);
+                        
+                        Assert.AreEqual("a", cppFunctionType.Parameters[0].Name);
+                        Assert.AreEqual(CppPrimitiveType.Int, cppFunctionType.Parameters[0].Type);
+                        
+                        Assert.AreEqual("b", cppFunctionType.Parameters[1].Name);
+                        Assert.AreEqual(CppPrimitiveType.Float, cppFunctionType.Parameters[1].Type);
+                    }
+                    
+                    {
+                        var cppType = cls.Fields[1].Type;
+                        Assert.AreEqual(CppTypeKind.Pointer, cppType.TypeKind);
+                        var cppPointerType = (CppPointerType) cppType;
+                        Assert.AreEqual(CppTypeKind.Function, cppPointerType.ElementType.TypeKind);
+                        var cppFunctionType = (CppFunctionType) cppPointerType.ElementType;
+                        Assert.AreEqual(2, cppFunctionType.Parameters.Count);
+                        
+                        Assert.AreEqual(string.Empty, cppFunctionType.Parameters[0].Name);
+                        Assert.AreEqual(CppPrimitiveType.Char, cppFunctionType.Parameters[0].Type);
+                        
+                        Assert.AreEqual(string.Empty, cppFunctionType.Parameters[1].Name);
+                        Assert.AreEqual(CppPrimitiveType.Int, cppFunctionType.Parameters[1].Type);
+                    }
+
+                }
+            );
+        }
+
 
         [Test]
         public void TestFunctionExport()

--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -627,7 +627,7 @@ namespace CppAst
         private CppField VisitFieldOrVariable(CppContainerContext containerContext, CXCursor cursor, CXCursor parent, CXClientData data)
         {
             var fieldName = GetCursorSpelling(cursor);
-            var type = GetCppType(cursor.Type.Declaration, cursor.Type, parent, data);
+            var type = GetCppType(cursor.Type.Declaration, cursor.Type, cursor, data);
 
             var cppField = new CppField(type, fieldName)
             {


### PR DESCRIPTION
Hi, thanks for this library - I'm making good use of it to generate a pinvoke wrapper using Roslyn AST to generate the code. It's working well apart from this bug I hit with a struct that contains function pointer fields, the CppAst result duplicated the first function pointer field's parmaters to all the rest. See the test for an example.

The fix makes sense to me, and passes current test suite but I might be going the wrong way with it. I've not used libclang before.