### PR TITLE
Adding support for skipping the parsing of SystemInclude Headers

### DIFF
--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -20,7 +20,6 @@ namespace CppAst
         private readonly CppContainerContext _rootContainerContext;
         private readonly Dictionary<string, CppContainerContext> _containers;
         private readonly Dictionary<string, CppType> _typedefs;
-        private bool _isEntryVisitSystem;
 
         public CppModelBuilder()
         {
@@ -47,7 +46,6 @@ namespace CppAst
             {
                 if (!ParseSystemIncludes) return CXChildVisitResult.CXChildVisit_Continue;
 
-                _isEntryVisitSystem = true;
                 _rootContainerContext.Container = _rootCompilation.System;
             }
             return VisitMember(cursor, parent, data);

--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -47,7 +47,7 @@ namespace CppAst
             {
                 if (!ParseSystemIncludes) return CXChildVisitResult.CXChildVisit_Continue;
 
-                _isEntryVisitSystem = cursor.Location.IsInSystemHeader;
+                _isEntryVisitSystem = true;
                 _rootContainerContext.Container = _rootCompilation.System;
             }
             return VisitMember(cursor, parent, data);

--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -32,6 +32,8 @@ namespace CppAst
 
         public bool AutoSquashTypedef { get; set; }
 
+        public bool ParseSystemIncludes { get; set; }
+
         public CppCompilation RootCompilation => _rootCompilation;
 
         public CXChildVisitResult VisitTranslationUnit(CXCursor cursor, CXCursor parent, CXClientData data)
@@ -40,9 +42,12 @@ namespace CppAst
 
             _rootContainerContext.Container = _rootCompilation;
 
-            _isEntryVisitSystem = cursor.Location.IsInSystemHeader;
+            
             if (cursor.Location.IsInSystemHeader)
             {
+                if (!ParseSystemIncludes) return CXChildVisitResult.CXChildVisit_Continue;
+
+                _isEntryVisitSystem = cursor.Location.IsInSystemHeader;
                 _rootContainerContext.Container = _rootCompilation.System;
             }
             return VisitMember(cursor, parent, data);

--- a/src/CppAst/CppParser.cs
+++ b/src/CppAst/CppParser.cs
@@ -119,7 +119,7 @@ namespace CppAst
 
             using (var createIndex = CXIndex.Create())
             {
-                var builder = new CppModelBuilder { AutoSquashTypedef = options.AutoSquashTypedef };
+                var builder = new CppModelBuilder { AutoSquashTypedef = options.AutoSquashTypedef, ParseSystemIncludes = options.ParseSystemIncludes };
                 var compilation = builder.RootCompilation;
 
                 string rootFileName = CppAstRootFileName;

--- a/src/CppAst/CppParserOptions.cs
+++ b/src/CppAst/CppParserOptions.cs
@@ -29,6 +29,7 @@ namespace CppAst
             AutoSquashTypedef = true;
             ParseMacros = false;
             ParseComments = true;
+            ParseSystemIncludes = true;
 
             // Default triple targets
             TargetCpu = IntPtr.Size == 8 ? CppTargetCpu.X86_64 : CppTargetCpu.X86;
@@ -77,7 +78,12 @@ namespace CppAst
         /// Gets or sets a boolean indicating whether un-named enum/struct referenced by a typedef will be renamed directly to the typedef name. Default is <c>true</c>
         /// </summary>
         public bool AutoSquashTypedef { get; set; }
-        
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether to parse System Include headers. Default is <c>true</c>
+        /// </summary>
+        public bool ParseSystemIncludes { get; set; }
+
         /// <summary>
         /// Sets <see cref="ParseMacros"/> to <c>true</c> and return this instance.
         /// </summary>


### PR DESCRIPTION
Right now if you have a larger project that includes many 3rd party headers or pulls in a lot of system headers, this can increase the parse time a huge amount especially if you don't care about the results of that content. 

This adds an option that allows you to skip the parsing of SystemIncludes, which in my case resulted with my parse going from 38s to 1s (since a large chunk of the code pulls in 3rd party libs). 

I do understand if this is not something you want to support but I thought I would make the PR anyway. :D 

