### PR TITLE
Better Attribute parsing support

### DIFF
--- a/src/CppAst.Tests/TestAttributes.cs
+++ b/src/CppAst.Tests/TestAttributes.cs
@@ -96,5 +96,192 @@ struct __declspec(uuid(""1841e5c8-16b0-489b-bcc8-44cfb0d5deae"")) __declspec(nov
                 },
                 new CppParserOptions().ConfigureForWindowsMsvc());
         }
+
+        [Test]
+        public void TestCpp11StructAttributes()
+        {
+            ParseAssert(@"
+struct [[deprecated]] Test{
+    int a;
+    int b;
+};
+
+struct [[deprecated(""old"")]] TestMessage{
+    int a;
+    int b;
+};", compilation =>
+            {
+                Assert.False(compilation.HasErrors);
+
+                Assert.AreEqual(2, compilation.Classes.Count);
+                Assert.AreEqual(1, compilation.Classes[0].Attributes.Count);
+                {
+                    var attr = compilation.Classes[0].Attributes[0];
+                    Assert.AreEqual("deprecated", attr.Name);
+                }
+
+                Assert.AreEqual(1, compilation.Classes[1].Attributes.Count);
+                {
+                    var attr = compilation.Classes[1].Attributes[0];
+                    Assert.AreEqual("deprecated", attr.Name);
+                    Assert.AreEqual("\"old\"", attr.Arguments);
+                }
+            },
+            // we are using a C++14 attribute because it can be used everywhere
+            new CppParserOptions() { AdditionalArguments = { "-std=c++14" } } 
+          );
+        }
+
+        [Test]
+        public void TestCpp11VariablesAttributes()
+        {
+            ParseAssert(@"
+struct Test{
+    [[deprecated]] int a;
+    int b;
+};
+
+[[deprecated]] int x;", compilation =>
+            {
+                Assert.False(compilation.HasErrors);
+
+                Assert.AreEqual(1, compilation.Classes.Count);
+                Assert.AreEqual(2, compilation.Classes[0].Fields.Count);
+                Assert.AreEqual(1, compilation.Classes[0].Fields[0].Attributes.Count);
+                {
+                    var attr = compilation.Classes[0].Fields[0].Attributes[0];
+                    Assert.AreEqual("deprecated", attr.Name);
+                }
+
+                Assert.AreEqual(1, compilation.Fields.Count);
+                Assert.AreEqual(1, compilation.Fields[0].Attributes.Count);
+                {
+                    var attr = compilation.Fields[0].Attributes[0];
+                    Assert.AreEqual("deprecated", attr.Name);
+                }
+            },
+            // we are using a C++14 attribute because it can be used everywhere
+            new CppParserOptions() { AdditionalArguments = { "-std=c++14" } }
+          );
+        }
+
+        [Test]
+        public void TestCpp11FunctionsAttributes()
+        {
+            ParseAssert(@"
+[[noreturn]] void x() {};", compilation =>
+            {
+                Assert.False(compilation.HasErrors);
+
+                Assert.AreEqual(1, compilation.Functions.Count);
+                Assert.AreEqual(1, compilation.Functions[0].Attributes.Count);
+                {
+                    var attr = compilation.Functions[0].Attributes[0];
+                    Assert.AreEqual("noreturn", attr.Name);
+                }
+            },
+            // we are using a C++14 attribute because it can be used everywhere
+            new CppParserOptions() { AdditionalArguments = { "-std=c++14" } }
+          );
+        }
+
+        [Test]
+        public void TestCpp11NamespaceAttributes()
+        {
+            ParseAssert(@"
+namespace [[deprecated]] cppast {};", compilation =>
+            {
+                Assert.False(compilation.HasErrors);
+
+                Assert.AreEqual(1, compilation.Namespaces.Count);
+                Assert.AreEqual(1, compilation.Namespaces[0].Attributes.Count);
+                {
+                    var attr = compilation.Namespaces[0].Attributes[0];
+                    Assert.AreEqual("deprecated", attr.Name);
+                }
+            },
+            // we are using a C++14 attribute because it can be used everywhere
+            new CppParserOptions() { AdditionalArguments = { "-std=c++14" } }
+          );
+        }
+
+        [Test]
+        public void TestCpp11EnumAttributes()
+        {
+            ParseAssert(@"
+enum [[deprecated]] E { };", compilation =>
+            {
+                Assert.False(compilation.HasErrors);
+
+                Assert.AreEqual(1, compilation.Enums.Count);
+                Assert.AreEqual(1, compilation.Enums[0].Attributes.Count);
+                {
+                    var attr = compilation.Enums[0].Attributes[0];
+                    Assert.AreEqual("deprecated", attr.Name);
+                }
+            },
+            // we are using a C++14 attribute because it can be used everywhere
+            new CppParserOptions() { AdditionalArguments = { "-std=c++14" } }
+          );
+        }
+
+        [Test]
+        public void TestCpp11TemplateStructAttributes()
+        {
+            ParseAssert(@"
+template<typename T> struct X {};
+template<> struct [[deprecated]] X<int> {};", compilation =>
+            {
+                Assert.False(compilation.HasErrors);
+
+                Assert.AreEqual(2, compilation.Classes.Count);
+                Assert.AreEqual(0, compilation.Classes[0].Attributes.Count);
+                Assert.AreEqual(1, compilation.Classes[1].Attributes.Count);                
+                {
+                    var attr = compilation.Classes[1].Attributes[0];
+                    Assert.AreEqual("deprecated", attr.Name);
+                }
+            },
+            // we are using a C++14 attribute because it can be used everywhere
+            new CppParserOptions() { AdditionalArguments = { "-std=c++14" } }
+          );
+        }
+
+        [Test]
+        public void TestCpp17StructUnknownAttributes()
+        {
+            ParseAssert(@"
+struct [[cppast]] Test{
+    int a;
+    int b;
+};
+
+struct [[cppast(""old"")]] TestMessage{
+    int a;
+    int b;
+};", compilation =>
+            {
+                Assert.False(compilation.HasErrors);
+
+                Assert.AreEqual(2, compilation.Classes.Count);
+                Assert.AreEqual(1, compilation.Classes[0].Attributes.Count);
+                {
+                    var attr = compilation.Classes[0].Attributes[0];
+                    Assert.AreEqual("cppast", attr.Name);
+                }
+
+                Assert.AreEqual(1, compilation.Classes[1].Attributes.Count);
+                {
+                    var attr = compilation.Classes[1].Attributes[0];
+                    Assert.AreEqual("cppast", attr.Name);
+                    Assert.AreEqual("\"old\"", attr.Arguments);
+                }
+            },
+            // C++17 says if the compile encounters a attribute it doesn't understand
+            // it will ignore that attribute and not throw an error, we still want to
+            // parse this.
+            new CppParserOptions() { AdditionalArguments = { "-std=c++17" } }
+          );
+        }
     }
 }

--- a/src/CppAst.Tests/TestFunctions.cs
+++ b/src/CppAst.Tests/TestFunctions.cs
@@ -187,7 +187,7 @@ int function1();
                     }
                     {
                         var cppFunction = compilation.Functions[1];
-                        Assert.Null(cppFunction.Attributes);
+                        Assert.AreEqual(0, cppFunction.Attributes.Count);
                         Assert.True(cppFunction.IsPublicExport());
                     }
                 }
@@ -207,7 +207,7 @@ int function1();
                     }
                     {
                         var cppFunction = compilation.Functions[1];
-                        Assert.Null(cppFunction.Attributes);
+                        Assert.AreEqual(0, cppFunction.Attributes.Count);
                         Assert.True(cppFunction.IsPublicExport());
                     }
                 }, new CppParserOptions().ConfigureForWindowsMsvc()

--- a/src/CppAst/CppClass.cs
+++ b/src/CppAst/CppClass.cs
@@ -43,7 +43,7 @@ namespace CppAst
         public CppVisibility Visibility { get; set; }
 
         /// <inheritdoc />
-        public CppContainerList<CppAttribute> Attributes { get; set; }
+        public CppContainerList<CppAttribute> Attributes { get; }
 
         /// <summary>
         /// Gets or sets a boolean indicating if this type is a definition. If <c>false</c> the type was only declared but is not defined.

--- a/src/CppAst/CppClass.cs
+++ b/src/CppAst/CppClass.cs
@@ -28,6 +28,7 @@ namespace CppAst
             Classes = new CppContainerList<CppClass>(this);
             Typedefs = new CppContainerList<CppTypedef>(this);
             TemplateParameters = new List<CppTemplateParameterType>();
+            Attributes = new CppContainerList<CppAttribute>(this);
         }
         
         /// <summary>
@@ -41,10 +42,8 @@ namespace CppAst
         /// <inheritdoc />
         public CppVisibility Visibility { get; set; }
 
-        /// <summary>
-        /// Gets the list of attached attributes. Might be null.
-        /// </summary>
-        public List<CppAttribute> Attributes { get; set; }
+        /// <inheritdoc />
+        public CppContainerList<CppAttribute> Attributes { get; set; }
 
         /// <summary>
         /// Gets or sets a boolean indicating if this type is a definition. If <c>false</c> the type was only declared but is not defined.

--- a/src/CppAst/CppContainerList.cs
+++ b/src/CppAst/CppContainerList.cs
@@ -51,6 +51,17 @@ namespace CppAst
             _elements.Add(item);
         }
 
+        public void AddRange(IEnumerable<TElement> collection)
+        {
+            if (collection != null)
+            {
+                foreach (var element in collection)
+                {
+                    Add(element);
+                }
+            }            
+        }
+
         public void Clear()
         {
             foreach (var element in _elements)

--- a/src/CppAst/CppEnum.cs
+++ b/src/CppAst/CppEnum.cs
@@ -21,6 +21,7 @@ namespace CppAst
         {
             Name = name;
             Items = new CppContainerList<CppEnumItem>(this);
+            Attributes = new CppContainerList<CppAttribute>(this);
         }
 
         /// <inheritdoc />
@@ -46,6 +47,11 @@ namespace CppAst
         public CppContainerList<CppEnumItem> Items { get; }
         
         public bool IsAnonymous { get; set; }
+
+        /// <summary>
+        /// Gets the list of attached attributes.
+        /// </summary>
+        public CppContainerList<CppAttribute> Attributes { get; }
 
         private bool Equals(CppEnum other)
         {

--- a/src/CppAst/CppFunction.cs
+++ b/src/CppAst/CppFunction.cs
@@ -21,6 +21,7 @@ namespace CppAst
             Name = name;
             Parameters = new CppContainerList<CppParameter>(this);
             TemplateParameters = new List<CppTemplateParameterType>();
+            Attributes = new CppContainerList<CppAttribute>(this);
         }
 
         /// <inheritdoc />
@@ -32,9 +33,9 @@ namespace CppAst
         public CppCallingConvention CallingConvention { get; set; }
 
         /// <summary>
-        /// Gets the attached attributes. Might be null.
+        /// Gets the attached attributes.
         /// </summary>
-        public List<CppAttribute> Attributes { get; set; }
+        public CppContainerList<CppAttribute> Attributes { get; set; }
 
         /// <summary>
         /// Gets or sets the storage qualifier.

--- a/src/CppAst/CppFunction.cs
+++ b/src/CppAst/CppFunction.cs
@@ -35,7 +35,7 @@ namespace CppAst
         /// <summary>
         /// Gets the attached attributes.
         /// </summary>
-        public CppContainerList<CppAttribute> Attributes { get; set; }
+        public CppContainerList<CppAttribute> Attributes { get; }
 
         /// <summary>
         /// Gets or sets the storage qualifier.

--- a/src/CppAst/CppGlobalDeclarationContainer.cs
+++ b/src/CppAst/CppGlobalDeclarationContainer.cs
@@ -59,7 +59,7 @@ namespace CppAst
         public CppContainerList<CppNamespace> Namespaces { get; }
 
         /// <inheritdoc />
-        public CppContainerList<CppAttribute> Attributes { get; set; }
+        public CppContainerList<CppAttribute> Attributes { get; }
 
         public virtual IEnumerable<ICppDeclaration> Children()
         {

--- a/src/CppAst/CppGlobalDeclarationContainer.cs
+++ b/src/CppAst/CppGlobalDeclarationContainer.cs
@@ -29,6 +29,7 @@ namespace CppAst
             Classes = new CppContainerList<CppClass>(this);
             Typedefs = new CppContainerList<CppTypedef>(this);
             Namespaces = new CppContainerList<CppNamespace>(this);
+            Attributes = new CppContainerList<CppAttribute>(this);
         }
 
         /// <summary>
@@ -56,6 +57,9 @@ namespace CppAst
 
         /// <inheritdoc />
         public CppContainerList<CppNamespace> Namespaces { get; }
+
+        /// <inheritdoc />
+        public CppContainerList<CppAttribute> Attributes { get; set; }
 
         public virtual IEnumerable<ICppDeclaration> Children()
         {

--- a/src/CppAst/CppNamespace.cs
+++ b/src/CppAst/CppNamespace.cs
@@ -25,6 +25,7 @@ namespace CppAst
             Classes = new CppContainerList<CppClass>(this);
             Typedefs = new CppContainerList<CppTypedef>(this);
             Namespaces = new CppContainerList<CppNamespace>(this);
+            Attributes = new CppContainerList<CppAttribute>(this);
         }
         
         /// <summary>
@@ -49,6 +50,9 @@ namespace CppAst
 
         /// <inheritdoc />
         public CppContainerList<CppNamespace> Namespaces { get; }
+
+        /// <inheritdoc />
+        public CppContainerList<CppAttribute> Attributes { get; }
 
         protected bool Equals(CppNamespace other)
         {

--- a/src/CppAst/ICppDeclarationContainer.cs
+++ b/src/CppAst/ICppDeclarationContainer.cs
@@ -34,5 +34,10 @@ namespace CppAst
         /// Gets the typedefs.
         /// </summary>
         CppContainerList<CppTypedef> Typedefs { get; }
+
+        /// <summary>
+        /// Gets the attributes.
+        /// </summary>
+        CppContainerList<CppAttribute> Attributes { get; }
     }
 }


### PR DESCRIPTION
This PR is a little complicated when C++11 added support for a standard around attributes, it had some rules around what was valid and what wasn't valid. In many cases, libClang doesn't give us all the information we need to be able to parse these attributes, and this became even more so of a thing when C++17 allowed for essentially user-defined attributes because the compiler would no longer complain about an attribute it didn't know about it just ignores it.

In this PR we when we parse attributes we need to take some manual steps to resolve cases where we are using C++11 style attributes and libClang doesn't return to the developer the actual proper CXSourceRanges that include these attributes. This why the AttributeTokenizer has been introduced and essentially creates its own range based on some manual walking of the CXTranslationUnit when certain requirements are met. 

So now cases of the following will return back attributes where cppast is a user-defined attribute(assuming you are compiling with c++17): 
```
struct [[cppast]] Test{
    int a;
    int b;
};

struct [[cppast(""old"")]] TestMessage{
    int a;
    int b;
};
```
which then allows the developer to use them for things like codegen etc... and its a more accurate representation of the AST.

This covers most cases but there are some places where it falls short (and can be updated when needed) such as: 

EnumItems will not be parsed with proper attributes: 

`enum { A [[deprecated]], B [[deprecated]] = 42 };`

Also, cases where attributes are put at the end of a function which is valid but generally not used so I didn't add support for it but the code could be easily extended to allow for that.

This PR also extends attribute support in general to Enum and Namespaces, and has better parsing of Templated types and functions. 