### PR TITLE
Fixing infinite loop issue caused by attribute parsing. 

### DIFF
--- a/src/CppAst.Tests/TestAttributes.cs
+++ b/src/CppAst.Tests/TestAttributes.cs
@@ -394,5 +394,31 @@ int function1(int a, int b);
                 Assert.AreEqual(1, compilation.Functions[0].Attributes.Count);
             });
         }
+
+        [Test]
+        public void TestCommentWithAttributeCharacters()
+        {
+            ParseAssert(@"
+// (infinite loop)
+// [[infinite loop]]
+// bug(infinite loop)
+int function1(int a, int b);", compilation =>
+            {
+                Assert.False(compilation.HasErrors);
+
+                var expectedText = @"(infinite loop)
+[[infinite loop]]
+bug(infinite loop)";
+
+                Assert.AreEqual(1, compilation.Functions.Count);
+                var resultText = compilation.Functions[0].Comment?.ToString();
+
+                expectedText = expectedText.Replace("\r\n", "\n");
+                resultText = resultText?.Replace("\r\n", "\n");
+                Assert.AreEqual(expectedText, resultText);
+
+                Assert.AreEqual(0, compilation.Functions[0].Attributes.Count);
+            });
+        }
     }
 }

--- a/src/CppAst.Tests/TestAttributes.cs
+++ b/src/CppAst.Tests/TestAttributes.cs
@@ -420,5 +420,29 @@ bug(infinite loop)";
                 Assert.AreEqual(0, compilation.Functions[0].Attributes.Count);
             });
         }
+
+        [Test]
+        public void TestAttributeInvalidBracketEnd()
+        {
+            ParseAssert(@"
+// noreturn]]
+int function1(int a, int b);", compilation =>
+            {
+                Assert.False(compilation.HasErrors);
+                Assert.AreEqual(0, compilation.Functions[0].Attributes.Count);
+            });
+        }
+
+        [Test]
+        public void TestAttributeInvalidParenEnd()
+        {
+            ParseAssert(@"
+// noreturn)
+int function1(int a, int b);", compilation =>
+            {
+                Assert.False(compilation.HasErrors);
+                Assert.AreEqual(0, compilation.Functions[0].Attributes.Count);
+            });
+        }
     }
 }

--- a/src/CppAst.Tests/TestComments.cs
+++ b/src/CppAst.Tests/TestComments.cs
@@ -116,5 +116,26 @@ And another line with @a x and @a y in italics
                 Assert.AreEqual(expectedText, resultText);
             });
         }
+
+        [Test]
+        public void TestParen()
+        {
+            ParseAssert(@"
+// [infinite loop)
+int function1(int a, int b);
+", compilation =>
+            {
+                Assert.False(compilation.HasErrors);
+
+                var expectedText = @"[infinite loop)";
+
+                Assert.AreEqual(1, compilation.Functions.Count);
+                var resultText = compilation.Functions[0].Comment?.ToString();
+
+                expectedText = expectedText.Replace("\r\n", "\n");
+                resultText = resultText?.Replace("\r\n", "\n");
+                Assert.AreEqual(expectedText, resultText);
+            });
+        }
     }
 }

--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -2134,12 +2134,12 @@ namespace CppAst
                         return false;
                 }
 
-                bool CheckValidOrReplace(ref CXSourceLocation checkedLocation, CXSourceLocation replacedWithLocation)
+                bool CheckIfValidOrReset(ref CXSourceLocation checkedLocation, CXSourceLocation resetLocation)
                 {
                     bool isValid = true;
                     if (checkedLocation.Equals(CXSourceLocation.Null))
                     {
-                        checkedLocation = replacedWithLocation;
+                        checkedLocation = resetLocation;
                         isValid = false;
                     }
 
@@ -2160,7 +2160,7 @@ namespace CppAst
                             while (!ConsumeIfTokenBeforeIs(ref begin, "[[") && isValid)
                             {
                                 begin = GetPrevLocation(begin, 1);
-                                isValid = CheckValidOrReplace(ref begin, saveBegin);
+                                isValid = CheckIfValidOrReset(ref begin, saveBegin);
                             }
 
                             if (!isValid)
@@ -2184,7 +2184,7 @@ namespace CppAst
                                 // with the potential of alignas, so we just break, which
                                 // will cause ConsumeIfTokenBeforeIs(ref begin, "alignas") to be false
                                 // and thus fall back to saveBegin which is the correct behavior
-                                if (!CheckValidOrReplace(ref begin, saveBegin))
+                                if (!CheckIfValidOrReset(ref begin, saveBegin))
                                     break;
                             }
 


### PR DESCRIPTION
Fixing issues where if you had a ) in a comment it would cause an infinite loop mentioned in issue #17 

I also added support for properly parsing "alignas" attribute