### PR TITLE
Attributes on Vars with in-lined types. 

### DIFF
--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -2270,7 +2270,13 @@ namespace CppAst
                     doesn't currently support all cases but it supports most valid cases.
                 */ 
                 var range = GetExtent(_tu, cursor.IncludedFile, cursor);
-                return range.Item1;
+
+                var beg = range.Item1.Start;
+                var end = range.Item1.End;
+                if (!range.Item2.Equals(CXSourceRange.Null))
+                    end = range.Item2.End;
+
+                return clang.getRange(beg, end);
             }
         }
 


### PR DESCRIPTION
So this is a case where if you have an attribute on a variable that has an inlined type such as a `std::vector<int>` libClang doesn't treat this the same way as a standard variable so its require that we parse it slightly differently which we were doing but we were not including the result of that in the final range that gets returned back to `AttributeTokenParser`.

We now do this where if we have a secondary range which happens in this case, we then include that range in the final range that gets sent back. 

I have added two tests, one that covers this case and another that verifies other template cases. 