### PR TITLE
add ParseAttributes option

### DIFF
--- a/src/CppAst.Tests/TestAttributes.cs
+++ b/src/CppAst.Tests/TestAttributes.cs
@@ -61,7 +61,7 @@ void *fun2(int align) __attribute__((alloc_align(1)));
                     Assert.AreEqual("alloc_align(1)", compilation.Functions[2].Attributes[0].ToString());
 
                 },
-                new CppParserOptions().ConfigureForWindowsMsvc() // Force using X86 to get __stdcall calling convention
+                new CppParserOptions() { ParseAttributes = true }.ConfigureForWindowsMsvc() // Force using X86 to get __stdcall calling convention
             );
         }
 
@@ -94,7 +94,7 @@ struct __declspec(uuid(""1841e5c8-16b0-489b-bcc8-44cfb0d5deae"")) __declspec(nov
                         Assert.Null(attr.Arguments);
                     }
                 },
-                new CppParserOptions().ConfigureForWindowsMsvc());
+                new CppParserOptions() { ParseAttributes = true }.ConfigureForWindowsMsvc());
         }
 
         [Test]
@@ -113,7 +113,7 @@ alignas(128) char cacheline[128];", compilation =>
                 }
             },
             // we are using a C++14 attribute because it can be used everywhere
-            new CppParserOptions() { AdditionalArguments = { "-std=c++14" } }
+            new CppParserOptions() { AdditionalArguments = { "-std=c++14" }, ParseAttributes = true }
           );
         }
 
@@ -133,7 +133,7 @@ struct alignas(8) S {};", compilation =>
                 }
             },
             // we are using a C++14 attribute because it can be used everywhere
-            new CppParserOptions() { AdditionalArguments = { "-std=c++14" } }
+            new CppParserOptions() { AdditionalArguments = { "-std=c++14" }, ParseAttributes = true }
           );
         }
 
@@ -158,7 +158,7 @@ struct [[deprecated]] alignas(8) S {};", compilation =>
                 }
             },
             // we are using a C++14 attribute because it can be used everywhere
-            new CppParserOptions() { AdditionalArguments = { "-std=c++14" } }
+            new CppParserOptions() { AdditionalArguments = { "-std=c++14" }, ParseAttributes = true  }
           );
         }
 
@@ -193,7 +193,7 @@ struct [[deprecated(""old"")]] TestMessage{
                 }
             },
             // we are using a C++14 attribute because it can be used everywhere
-            new CppParserOptions() { AdditionalArguments = { "-std=c++14" } } 
+            new CppParserOptions() { AdditionalArguments = { "-std=c++14" }, ParseAttributes = true  } 
           );
         }
 
@@ -226,7 +226,7 @@ struct Test{
                 }
             },
             // we are using a C++14 attribute because it can be used everywhere
-            new CppParserOptions() { AdditionalArguments = { "-std=c++14" } }
+            new CppParserOptions() { AdditionalArguments = { "-std=c++14" }, ParseAttributes = true  }
           );
         }
 
@@ -246,7 +246,7 @@ struct Test{
                 }
             },
             // we are using a C++14 attribute because it can be used everywhere
-            new CppParserOptions() { AdditionalArguments = { "-std=c++14" } }
+            new CppParserOptions() { AdditionalArguments = { "-std=c++14" }, ParseAttributes = true  }
           );
         }
 
@@ -266,7 +266,7 @@ namespace [[deprecated]] cppast {};", compilation =>
                 }
             },
             // we are using a C++14 attribute because it can be used everywhere
-            new CppParserOptions() { AdditionalArguments = { "-std=c++14" } }
+            new CppParserOptions() { AdditionalArguments = { "-std=c++14" }, ParseAttributes = true  }
           );
         }
 
@@ -286,7 +286,7 @@ enum [[deprecated]] E { };", compilation =>
                 }
             },
             // we are using a C++14 attribute because it can be used everywhere
-            new CppParserOptions() { AdditionalArguments = { "-std=c++14" } }
+            new CppParserOptions() { AdditionalArguments = { "-std=c++14" }, ParseAttributes = true }
           );
         }
 
@@ -308,7 +308,7 @@ template<> struct [[deprecated]] X<int> {};", compilation =>
                 }
             },
             // we are using a C++14 attribute because it can be used everywhere
-            new CppParserOptions() { AdditionalArguments = { "-std=c++14" } }
+            new CppParserOptions() { AdditionalArguments = { "-std=c++14" }, ParseAttributes = true }
           );
         }
 
@@ -345,7 +345,7 @@ struct [[cppast(""old"")]] TestMessage{
             // C++17 says if the compile encounters a attribute it doesn't understand
             // it will ignore that attribute and not throw an error, we still want to
             // parse this.
-            new CppParserOptions() { AdditionalArguments = { "-std=c++17" } }
+            new CppParserOptions() { AdditionalArguments = { "-std=c++17" }, ParseAttributes = true }
           );
         }
 
@@ -369,7 +369,8 @@ int function1(int a, int b);
                 Assert.AreEqual(expectedText, resultText);
 
                 Assert.AreEqual(0, compilation.Functions[0].Attributes.Count);
-            });
+            },
+            new CppParserOptions() { ParseAttributes = true });
         }
 
         [Test]
@@ -392,7 +393,8 @@ int function1(int a, int b);
                 Assert.AreEqual(expectedText, resultText);
 
                 Assert.AreEqual(1, compilation.Functions[0].Attributes.Count);
-            });
+            },
+            new CppParserOptions() { ParseAttributes = true });
         }
 
         [Test]
@@ -418,7 +420,8 @@ bug(infinite loop)";
                 Assert.AreEqual(expectedText, resultText);
 
                 Assert.AreEqual(0, compilation.Functions[0].Attributes.Count);
-            });
+            },
+            new CppParserOptions() { ParseAttributes = true });
         }
 
         [Test]
@@ -430,7 +433,8 @@ int function1(int a, int b);", compilation =>
             {
                 Assert.False(compilation.HasErrors);
                 Assert.AreEqual(0, compilation.Functions[0].Attributes.Count);
-            });
+            },
+            new CppParserOptions() { ParseAttributes = true });
         }
 
         [Test]
@@ -442,7 +446,8 @@ int function1(int a, int b);", compilation =>
             {
                 Assert.False(compilation.HasErrors);
                 Assert.AreEqual(0, compilation.Functions[0].Attributes.Count);
-            });
+            },
+            new CppParserOptions() { ParseAttributes = true });
         }
 
         [Test]
@@ -470,7 +475,7 @@ struct Test{
             // C++17 says if the compile encounters a attribute it doesn't understand
             // it will ignore that attribute and not throw an error, we still want to
             // parse this.
-            new CppParserOptions() { AdditionalArguments = { "-std=c++17" } }
+            new CppParserOptions() { AdditionalArguments = { "-std=c++17" }, ParseAttributes = true }
           );
         }
 
@@ -495,7 +500,7 @@ struct Test{
             // C++17 says if the compile encounters a attribute it doesn't understand
             // it will ignore that attribute and not throw an error, we still want to
             // parse this.
-            new CppParserOptions() { AdditionalArguments = { "-std=c++17" } }
+            new CppParserOptions() { AdditionalArguments = { "-std=c++17" }, ParseAttributes = true }
           );
         }
 

--- a/src/CppAst.Tests/TestAttributes.cs
+++ b/src/CppAst.Tests/TestAttributes.cs
@@ -498,5 +498,21 @@ struct Test{
             new CppParserOptions() { AdditionalArguments = { "-std=c++17" } }
           );
         }
+
+        [Test]
+        public void TestCppNoParseOptionsAttributes()
+        {
+            ParseAssert(@"
+[[noreturn]] void x() {};", compilation =>
+            {
+                Assert.False(compilation.HasErrors);
+
+                Assert.AreEqual(1, compilation.Functions.Count);
+                Assert.AreEqual(0, compilation.Functions[0].Attributes.Count);
+            },
+            // we are using a C++14 attribute because it can be used everywhere
+            new CppParserOptions() { AdditionalArguments = { "-std=c++14" }, ParseAttributes = false }
+          );
+        }
     }
 }

--- a/src/CppAst.Tests/TestComments.cs
+++ b/src/CppAst.Tests/TestComments.cs
@@ -135,7 +135,8 @@ int function1(int a, int b);
                 expectedText = expectedText.Replace("\r\n", "\n");
                 resultText = resultText?.Replace("\r\n", "\n");
                 Assert.AreEqual(expectedText, resultText);
-            });
+            },
+            new CppParserOptions() { ParseAttributes = true });
         }
     }
 }

--- a/src/CppAst.Tests/TestFunctions.cs
+++ b/src/CppAst.Tests/TestFunctions.cs
@@ -190,7 +190,8 @@ int function1();
                         Assert.AreEqual(0, cppFunction.Attributes.Count);
                         Assert.True(cppFunction.IsPublicExport());
                     }
-                }
+                },
+                new CppParserOptions() { ParseAttributes = true }
             );
 
             ParseAssert(text,
@@ -210,7 +211,7 @@ int function1();
                         Assert.AreEqual(0, cppFunction.Attributes.Count);
                         Assert.True(cppFunction.IsPublicExport());
                     }
-                }, new CppParserOptions().ConfigureForWindowsMsvc()
+                }, new CppParserOptions() { ParseAttributes = true }.ConfigureForWindowsMsvc()
             );
         }
 

--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -33,6 +33,8 @@ namespace CppAst
 
         public bool ParseSystemIncludes { get; set; }
 
+        public bool ParseAttributeEnabled { get; set; }
+
         public CppCompilation RootCompilation => _rootCompilation;
 
         public CXChildVisitResult VisitTranslationUnit(CXCursor cursor, CXCursor parent, CXClientData data)
@@ -1220,6 +1222,8 @@ namespace CppAst
 
         private List<CppAttribute> ParseAttributes(CXCursor cursor)
         {
+            if (!ParseAttributeEnabled) return null;
+
             var tokenizer = new AttributeTokenizer(cursor);
             var tokenIt = new TokenIterator(tokenizer);
 
@@ -1249,6 +1253,8 @@ namespace CppAst
 
         private List<CppAttribute> ParseFunctionAttributes(CXCursor cursor, string functionName)
         {
+            if (!ParseAttributeEnabled) return null;
+
             // TODO: This function is not 100% correct when parsing tokens up to the function name
             // we assume to find the function name immediately followed by a `(`
             // but some return type parameter could actually interfere with that

--- a/src/CppAst/CppParser.cs
+++ b/src/CppAst/CppParser.cs
@@ -119,7 +119,12 @@ namespace CppAst
 
             using (var createIndex = CXIndex.Create())
             {
-                var builder = new CppModelBuilder { AutoSquashTypedef = options.AutoSquashTypedef, ParseSystemIncludes = options.ParseSystemIncludes };
+                var builder = new CppModelBuilder
+                {
+                    AutoSquashTypedef = options.AutoSquashTypedef,
+                    ParseSystemIncludes = options.ParseSystemIncludes,
+                    ParseAttributeEnabled = options.ParseAttributes,
+                };
                 var compilation = builder.RootCompilation;
 
                 string rootFileName = CppAstRootFileName;

--- a/src/CppAst/CppParserOptions.cs
+++ b/src/CppAst/CppParserOptions.cs
@@ -30,6 +30,7 @@ namespace CppAst
             ParseMacros = false;
             ParseComments = true;
             ParseSystemIncludes = true;
+            ParseAttributes = true;
 
             // Default triple targets
             TargetCpu = IntPtr.Size == 8 ? CppTargetCpu.X86_64 : CppTargetCpu.X86;
@@ -83,6 +84,11 @@ namespace CppAst
         /// Gets or sets a boolean indicating whether to parse System Include headers. Default is <c>true</c>
         /// </summary>
         public bool ParseSystemIncludes { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether to parse Attributes. Default is <c>true</c>
+        /// </summary>
+        public bool ParseAttributes { get; set; }
 
         /// <summary>
         /// Sets <see cref="ParseMacros"/> to <c>true</c> and return this instance.

--- a/src/CppAst/CppParserOptions.cs
+++ b/src/CppAst/CppParserOptions.cs
@@ -30,7 +30,7 @@ namespace CppAst
             ParseMacros = false;
             ParseComments = true;
             ParseSystemIncludes = true;
-            ParseAttributes = true;
+            ParseAttributes = false;
 
             // Default triple targets
             TargetCpu = IntPtr.Size == 8 ? CppTargetCpu.X86_64 : CppTargetCpu.X86;

--- a/src/CppAst/CppParserOptions.cs
+++ b/src/CppAst/CppParserOptions.cs
@@ -86,7 +86,7 @@ namespace CppAst
         public bool ParseSystemIncludes { get; set; }
 
         /// <summary>
-        /// Gets or sets a boolean indicating whether to parse Attributes. Default is <c>true</c>
+        /// Gets or sets a boolean indicating whether to parse Attributes. Default is <c>false</c>
         /// </summary>
         public bool ParseAttributes { get; set; }
 


### PR DESCRIPTION
This PR adds the `ParseAttributes` option to skip parsing attributes.

`ParseFunctionAttributes` and `ParseAttributes` function takes a long time to complete, so I propose to add an option to skip these functions.