### PR TITLE
add support for TemplateParameter parsing

### DIFF
--- a/src/CppAst.Tests/TestTypes.cs
+++ b/src/CppAst.Tests/TestTypes.cs
@@ -54,5 +54,44 @@ t1* f4;
                 }
             );
         }
+
+        [Test]
+        public void TestTemplateParameters()
+        {
+            ParseAssert(@"
+template <typename T, typename U>
+struct TemplateStruct
+{
+    T field0;
+    U field1;
+};
+
+struct Struct2
+{
+};
+
+::TemplateStruct<int, Struct2> exposed;
+TemplateStruct<int, Struct2> unexposed;
+",
+                compilation =>
+                {
+                    Assert.False(compilation.HasErrors);
+
+                    Assert.AreEqual(2, compilation.Fields.Count);
+
+                    var exposed = compilation.Fields[0].Type as CppClass;
+                    Assert.AreEqual("TemplateStruct", exposed.Name);
+                    Assert.AreEqual(2, exposed.TemplateParameters.Count);
+                    Assert.AreEqual(CppPrimitiveKind.Int, (exposed.TemplateParameters[0] as CppPrimitiveType).Kind);
+                    Assert.AreEqual("Struct2", (exposed.TemplateParameters[1] as CppClass).Name);
+
+                    var unexposed = compilation.Fields[1].Type as CppUnexposedType;
+                    Assert.AreEqual("TemplateStruct<int, Struct2>", unexposed.Name);
+                    Assert.AreEqual(2, unexposed.TemplateParameters.Count);
+                    Assert.AreEqual(CppPrimitiveKind.Int, (unexposed.TemplateParameters[0] as CppPrimitiveType).Kind);
+                    Assert.AreEqual("Struct2", (unexposed.TemplateParameters[1] as CppClass).Name);
+                }
+            );
+        }
     }
 }

--- a/src/CppAst/CppClass.cs
+++ b/src/CppAst/CppClass.cs
@@ -27,7 +27,7 @@ namespace CppAst
             Enums = new CppContainerList<CppEnum>(this);
             Classes = new CppContainerList<CppClass>(this);
             Typedefs = new CppContainerList<CppTypedef>(this);
-            TemplateParameters = new List<CppTemplateParameterType>();
+            TemplateParameters = new List<CppType>();
             Attributes = new CppContainerList<CppAttribute>(this);
         }
         
@@ -81,7 +81,7 @@ namespace CppAst
         public CppContainerList<CppTypedef> Typedefs { get; }
 
         /// <inheritdoc />
-        public List<CppTemplateParameterType> TemplateParameters { get; }
+        public List<CppType> TemplateParameters { get; }
 
         private bool Equals(CppClass other)
         {

--- a/src/CppAst/CppFunction.cs
+++ b/src/CppAst/CppFunction.cs
@@ -20,7 +20,7 @@ namespace CppAst
         {
             Name = name;
             Parameters = new CppContainerList<CppParameter>(this);
-            TemplateParameters = new List<CppTemplateParameterType>();
+            TemplateParameters = new List<CppType>();
             Attributes = new CppContainerList<CppAttribute>(this);
         }
 
@@ -71,7 +71,7 @@ namespace CppAst
         public CppFunctionFlags Flags { get; set; }
 
         /// <inheritdoc />
-        public List<CppTemplateParameterType> TemplateParameters { get; }
+        public List<CppType> TemplateParameters { get; }
 
         public override string ToString()
         {

--- a/src/CppAst/CppUnexposedType.cs
+++ b/src/CppAst/CppUnexposedType.cs
@@ -3,6 +3,7 @@
 // See license.txt file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace CppAst
 {
@@ -12,7 +13,7 @@ namespace CppAst
     /// <remarks>
     /// Template parameter type instance are actually exposed with this type.
     /// </remarks>
-    public sealed class CppUnexposedType : CppType
+    public sealed class CppUnexposedType : CppType, ICppTemplateOwner
     {
         /// <summary>
         /// Creates an instance of this type.
@@ -21,6 +22,7 @@ namespace CppAst
         public CppUnexposedType(string name) : base(CppTypeKind.Unexposed)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
+            TemplateParameters = new List<CppType>();
         }
 
         /// <summary>
@@ -34,6 +36,9 @@ namespace CppAst
         }
 
         public override int SizeOf { get; set; }
+
+        /// <inheritdoc />
+        public List<CppType> TemplateParameters { get; }
 
         public override bool Equals(object obj)
         {

--- a/src/CppAst/ICppTemplateOwner.cs
+++ b/src/CppAst/ICppTemplateOwner.cs
@@ -14,6 +14,6 @@ namespace CppAst
         /// <summary>
         /// List of template parameters.
         /// </summary>
-        List<CppTemplateParameterType> TemplateParameters { get; }
+        List<CppType> TemplateParameters { get; }
     }
 }


### PR DESCRIPTION
This PR adds TemplateParameter parsing to `CppClass` and `CppUnexposedType`.

Template parameters must be parsed recursively, so I changed TemplateParameters type to `List<CppType>`.

```cs
// ICppTemplateOwner

// before
List<CppTemplateParameterType> TemplateParameters { get; }

// after
List<CppType> TemplateParameters { get; }
```