### PR TITLE
Add support for specialized template

### DIFF
--- a/src/CppAst.Tests/TestTypes.cs
+++ b/src/CppAst.Tests/TestTypes.cs
@@ -101,5 +101,42 @@ TemplateStruct<int, Struct2> unexposed;
                 }
             );
         }
+
+        [Test]
+        public void TestTemplateInheritance()
+        {
+            ParseAssert(@"
+template <typename T>
+class BaseTemplate
+{
+};
+
+class Derived : public ::BaseTemplate<::Derived>
+{
+};
+",
+                compilation =>
+                {
+                    Assert.False(compilation.HasErrors);
+
+                    Assert.AreEqual(3, compilation.Classes.Count);
+
+                    var baseTemplate = compilation.Classes[0];
+                    var derived = compilation.Classes[1];
+                    var baseClassSpecialized = compilation.Classes[2];
+
+                    Assert.AreEqual("BaseTemplate", baseTemplate.Name);
+                    Assert.AreEqual("Derived", derived.Name);
+                    Assert.AreEqual("BaseTemplate", baseClassSpecialized.Name);
+
+                    Assert.AreEqual(1, derived.BaseTypes.Count);
+                    Assert.AreEqual(baseClassSpecialized, derived.BaseTypes[0].Type);
+
+                    Assert.AreEqual(1, baseClassSpecialized.TemplateParameters.Count);
+                    Assert.AreEqual(derived, baseClassSpecialized.TemplateParameters[0]);
+                    Assert.AreEqual(baseTemplate, baseClassSpecialized.SpecializedTemplate);
+                }
+            );
+        }
     }
 }

--- a/src/CppAst.Tests/TestTypes.cs
+++ b/src/CppAst.Tests/TestTypes.cs
@@ -85,6 +85,14 @@ TemplateStruct<int, Struct2> unexposed;
                     Assert.AreEqual(CppPrimitiveKind.Int, (exposed.TemplateParameters[0] as CppPrimitiveType).Kind);
                     Assert.AreEqual("Struct2", (exposed.TemplateParameters[1] as CppClass).Name);
 
+                    var specialized = exposed.SpecializedTemplate;
+                    Assert.AreEqual("TemplateStruct", specialized.Name);
+                    Assert.AreEqual(2, specialized.Fields.Count);
+                    Assert.AreEqual("field0", specialized.Fields[0].Name);
+                    Assert.AreEqual("T", specialized.Fields[0].Type.GetDisplayName());
+                    Assert.AreEqual("field1", specialized.Fields[1].Name);
+                    Assert.AreEqual("U", specialized.Fields[1].Type.GetDisplayName());
+
                     var unexposed = compilation.Fields[1].Type as CppUnexposedType;
                     Assert.AreEqual("TemplateStruct<int, Struct2>", unexposed.Name);
                     Assert.AreEqual(2, unexposed.TemplateParameters.Count);

--- a/src/CppAst/CppClass.cs
+++ b/src/CppAst/CppClass.cs
@@ -83,6 +83,11 @@ namespace CppAst
         /// <inheritdoc />
         public List<CppType> TemplateParameters { get; }
 
+        /// <summary>
+        /// Gets the specialized class template of this instance.
+        /// </summary>
+        public CppClass SpecializedTemplate { get; set; }
+
         private bool Equals(CppClass other)
         {
             return base.Equals(other) && Equals(Parent, other.Parent) && Name.Equals(other.Name);

--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -132,6 +132,11 @@ namespace CppAst
                         if (templateParameters != null)
                         {
                             cppClass.TemplateParameters.AddRange(templateParameters);
+
+                            if (cursor.DeclKind == CX_DeclKind.CX_DeclKind_ClassTemplateSpecialization)
+                            {
+                                cppClass.SpecializedTemplate = (CppClass)GetOrCreateDeclarationContainer(cursor.SpecializedCursorTemplate, data).Container;
+                            }
                         }
                     }
 


### PR DESCRIPTION
This PR adds to retrieve which templates are specialized.

### example

```
template <typename T>
class Foo {};

Foo<int> int_foo;
```

You can parse `Foo<int>` to get an `int` as a template parameter and `Foo<T>` as a specialization class template.