### PR TITLE
fix parsing qualifier

### DIFF
--- a/src/CppAst.Tests/TestTypes.cs
+++ b/src/CppAst.Tests/TestTypes.cs
@@ -138,5 +138,38 @@ class Derived : public ::BaseTemplate<::Derived>
                 }
             );
         }
+
+        [Test]
+        public void TestClassPrototype()
+        {
+            ParseAssert(@"
+namespace ns1 {
+class TmpClass;
+}
+
+namespace ns2 {
+const ns1::TmpClass* tmpClass1;
+volatile ns1::TmpClass* tmpClass2;
+}
+
+namespace ns1 {
+class TmpClass {
+};
+}
+",
+                compilation =>
+                {
+                    Assert.False(compilation.HasErrors);
+
+                    var tmpClass1 = compilation.Namespaces[1].Fields[0];
+                    var tmpClass2 = compilation.Namespaces[1].Fields[1];
+
+                    var hoge = tmpClass1.Type.GetDisplayName();
+                    var hoge2 = tmpClass2.Type.GetDisplayName();
+                    Assert.AreEqual("const TmpClass*", tmpClass1.Type.GetDisplayName());
+                    Assert.AreEqual("volatile TmpClass*", tmpClass2.Type.GetDisplayName());
+                }
+            );
+        }
     }
 }

--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -1554,10 +1554,22 @@ namespace CppAst
 
             if (type.IsConstQualified)
             {
+                // Skip if it is already qualified.
+                if (cppType is CppQualifiedType q && q.Qualifier == CppTypeQualifier.Const)
+                {
+                    return cppType;
+                }
+
                 return new CppQualifiedType(CppTypeQualifier.Const, cppType);
             }
             if (type.IsVolatileQualified)
             {
+                // Skip if it is already qualified.
+                if (cppType is CppQualifiedType q && q.Qualifier == CppTypeQualifier.Volatile)
+                {
+                    return cppType;
+                }
+
                 return new CppQualifiedType(CppTypeQualifier.Volatile, cppType);
             }
 


### PR DESCRIPTION
This PR fixes an issue where parsing a prototype-declared class would result in duplicate qualifiers being added.

```cpp
namespace ns1 {
class TmpClass;
}
namespace ns2 {
const ns1::TmpClass* tmpClass1;    // Type is const const TmpClass*
volatile ns1::TmpClass* tmpClass2;  // Type is volatile volatile TmpClass*
}
```