### PR TITLE
Improve parsing template

### DIFF
--- a/src/CppAst.Tests/TestAttributes.cs
+++ b/src/CppAst.Tests/TestAttributes.cs
@@ -463,7 +463,7 @@ struct Test{
             {
                 Assert.False(compilation.HasErrors);
 
-                Assert.AreEqual(2, compilation.Classes.Count);
+                Assert.AreEqual(3, compilation.Classes.Count);
                 Assert.AreEqual(1, compilation.Classes[1].Fields.Count);
                 Assert.AreEqual(1, compilation.Classes[1].Fields[0].Attributes.Count);
                 {

--- a/src/CppAst.Tests/TestTypeAliases.cs
+++ b/src/CppAst.Tests/TestTypeAliases.cs
@@ -124,7 +124,7 @@ using MyStructInt = MyStruct<int>;
                 compilation =>
                 {
                     Assert.False(compilation.HasErrors);
-                    Assert.AreEqual(1, compilation.Classes.Count);
+                    Assert.AreEqual(2, compilation.Classes.Count);
                     Assert.AreEqual("MyStruct", compilation.Classes[0].Name);
 
                     var cppStruct = compilation.FindByName<CppClass>("MyStruct");

--- a/src/CppAst.Tests/TestTypes.cs
+++ b/src/CppAst.Tests/TestTypes.cs
@@ -93,8 +93,8 @@ TemplateStruct<int, Struct2> unexposed;
                     Assert.AreEqual("field1", specialized.Fields[1].Name);
                     Assert.AreEqual("U", specialized.Fields[1].Type.GetDisplayName());
 
-                    var unexposed = compilation.Fields[1].Type as CppUnexposedType;
-                    Assert.AreEqual("TemplateStruct<int, Struct2>", unexposed.Name);
+                    var unexposed = compilation.Fields[1].Type as CppClass;
+                    Assert.AreEqual("TemplateStruct", unexposed.Name);
                     Assert.AreEqual(2, unexposed.TemplateParameters.Count);
                     Assert.AreEqual(CppPrimitiveKind.Int, (unexposed.TemplateParameters[0] as CppPrimitiveType).Kind);
                     Assert.AreEqual("Struct2", (unexposed.TemplateParameters[1] as CppClass).Name);

--- a/src/CppAst.Tests/TestTypes.cs
+++ b/src/CppAst.Tests/TestTypes.cs
@@ -98,6 +98,9 @@ TemplateStruct<int, Struct2> unexposed;
                     Assert.AreEqual(2, unexposed.TemplateParameters.Count);
                     Assert.AreEqual(CppPrimitiveKind.Int, (unexposed.TemplateParameters[0] as CppPrimitiveType).Kind);
                     Assert.AreEqual("Struct2", (unexposed.TemplateParameters[1] as CppClass).Name);
+
+                    Assert.AreNotEqual(exposed.GetHashCode(), specialized.GetHashCode());
+                    Assert.AreEqual(exposed.GetHashCode(), unexposed.GetHashCode());
                 }
             );
         }

--- a/src/CppAst/CppClass.cs
+++ b/src/CppAst/CppClass.cs
@@ -110,6 +110,10 @@ namespace CppAst
                 int hashCode = base.GetHashCode();
                 hashCode = (hashCode * 397) ^ (Parent != null ? Parent.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ Name.GetHashCode();
+                foreach (var templateParameter in TemplateParameters)
+                {
+                    hashCode = (hashCode * 397) ^ templateParameter.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -1671,6 +1671,13 @@ namespace CppAst
 
                 case CXTypeKind.CXType_Unexposed:
                     {
+                        // It may be possible to parse them even if they are unexposed.
+                        var kind = type.Declaration.Type.kind;
+                        if (kind != CXTypeKind.CXType_Unexposed && kind != CXTypeKind.CXType_Invalid)
+                        {
+                            return GetCppType(type.Declaration, type.Declaration.Type, parent, data);
+                        }
+
                         var cppUnexposedType = new CppUnexposedType(type.ToString()) { SizeOf = (int)type.SizeOf };
                         var templateParameters = ParseTemplateParameters(cursor, type, new CXClientData((IntPtr)data));
                         if (templateParameters != null)


### PR DESCRIPTION
This PR improves two template parsing.

1. Fixes a bug where the same `HashCode` is returned even if `TemplateParameters` is different.
1. Parse the `Declaration` even when the type is `CXType_Unexposed`.